### PR TITLE
Add Jest tests for calculateGrowth

### DIFF
--- a/__tests__/calculateGrowth.test.js
+++ b/__tests__/calculateGrowth.test.js
@@ -1,0 +1,18 @@
+const { calculateGrowth } = require('../script.js');
+
+describe('calculateGrowth', () => {
+  test('returns positive growth when current is greater than previous', () => {
+    const result = calculateGrowth(200, 100);
+    expect(result).toEqual({ value: 100, isPositive: true });
+  });
+
+  test('returns negative growth when current is less than previous', () => {
+    const result = calculateGrowth(80, 100);
+    expect(result).toEqual({ value: 20, isPositive: false });
+  });
+
+  test('handles previous value of zero', () => {
+    const result = calculateGrowth(50, 0);
+    expect(result).toEqual({ value: 0, isPositive: true });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nabataty-test-dashboard",
+  "version": "1.0.0",
+  "description": "Test dashboard for Nabataty",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -135,6 +135,11 @@ function calculateGrowth(current, previous) {
     };
 }
 
+// Export for testing environments like Node/Jest
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { calculateGrowth };
+}
+
 // Update comparison summary with data
 function updateComparisonSummary(revenue2025, orders2025, revenue2024, orders2024, period) {
     if (!isComparing) {


### PR DESCRIPTION
## Summary
- initialize Node and Jest setup
- export `calculateGrowth` for testing
- add tests for `calculateGrowth`

## Testing
- `npm test` *(fails: jest not found)*